### PR TITLE
consistency_checks.py: Fix skip errors handling of numeric arguments

### DIFF
--- a/consistency_checks.py
+++ b/consistency_checks.py
@@ -191,11 +191,14 @@ class ConsistencyChecks:
 
     def _skip_errors(self, stats):
         """Skip any known errors"""
-        if stats["missing"] > 0 and not stats["missing"] is self.check_missing_fields:
+        if stats["missing"] > 0 and (isinstance(self.check_missing_fields, bool) or
+                                     stats["missing"] != self.check_missing_fields):
             return False
-        elif stats["duplicate"] > 0 and not stats["duplicate"] is self.check_statement_dups:
+        elif stats["duplicate"] > 0 and (isinstance(self.check_statement_dups, bool) or
+                                         stats["duplicate"] != self.check_statement_dups):
             return False
-        elif stats["reference"] > 0 and not stats["reference"] is self.check_statement_refs:
+        elif stats["reference"] > 0 and (isinstance(self.check_statement_refs, bool) or
+                                         stats["reference"] != self.check_statement_refs):
             return False
         else:
             return True


### PR DESCRIPTION
Fix skip errors handling of both numeric and boolean arguments